### PR TITLE
remove assignment of GLOBAL causing warning

### DIFF
--- a/test/linkedList-spec.js
+++ b/test/linkedList-spec.js
@@ -1,6 +1,5 @@
 var window = window || undefined;
 if (!window) {
-  GLOBAL = window
   var vm = require('vm');
   var fs = require('fs');
   var sinon = require('sinon');


### PR DESCRIPTION
Use of `GLOBAL` was triggering deprecation warning. `GLOBAL` is now `global`.

If tests are run in node then window is set to undefined. The old code stepped on `GLOBAL` with window, which is undefined. Removed assignment.